### PR TITLE
Fixed add_object method so images and files can be uploaded, made content_type arg optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,10 @@ This will return a multi-dimentional array containing `name`, `content_type`, `b
 You will need to set the container first by using the method `set_container()`
 ```php
 $this->opencloud->set_container('MyContainer');
-$this->opencloud->add_object('text1.txt', file_get_contents('files/text1.txt'), 'text/plain');
-$this->opencloud->add_object('text2.txt', file_get_contents('files/text2.txt'), 'text/plain');
-$this->opencloud->add_object('text3.txt', file_get_contents('files/text3.txt'), 'text/plain');
+$this->opencloud->add_object('my_photo.img', 'path_to/my_photo.jpg','image/jpeg');
+
 ```
-The first paramater will be the name you will assign the object, the second is the contents of the file, and the third will be the Content-type of the file.
+The first parameter will be the name you will assign the object, the second is the path of the file, and the third will be the Content-type of the file (this is optional).
 
 ### <a name="delete_object"></a>Deleting Objects from a Container ###
 You will need to set the container first by using the method `set_container()`

--- a/application/libraries/Opencloud.php
+++ b/application/libraries/Opencloud.php
@@ -333,7 +333,7 @@ class Opencloud
 	 * @param	array	additional params to pass into the create data object call ( name, content_type, extra_headers, send_etag )
 	 * @return	bool 	TRUE on success, FALSE on failure  
 	 */   
-    public function add_object($name, $contents, $content_type, $extractArchive = null, $params = array()) {
+    public function add_object($name, $contents, $content_type = null, $extractArchive = null, $params = array()) {
 		$this->reset_request_response();
 		
         try {


### PR DESCRIPTION
The add_object method in the Opencloud class previously used the inherited SetData method which type cast its input into a string, thus not allowing file resources and images to upload properly. I fixed this, made content_type arg optional, and amended readme
